### PR TITLE
Fixed typo

### DIFF
--- a/views/docs/download.php
+++ b/views/docs/download.php
@@ -24,7 +24,7 @@ Apacheのmod_rewriteが有効なら何も行うことなく、このドキュメ
 デモを試すには以下を実行。<br>
 <pre class="card">
 echo 'CREATE DATABASE `pieni_crud`;' | mysql
-mysql pieni_crud < vendor/sagittar-org/pieni-crud/misc/pieni_crud.dump
+mysql pieni_crud < vendor/sagittar-org/pieni-crud/misc/pieni_crud.sql
 </pre>
 </p>
 <p>


### PR DESCRIPTION
```
mysql pieni_crud < vendor/sagittar-org/pieni-crud/misc/pieni_crud.dump
no such file or directory: ./vendor/sagittar-org/pieni-crud/misc/pieni_crud.dump
```